### PR TITLE
feat: Searchable モジュール実装 (#17)

### DIFF
--- a/lib/re_jp_prefecture.rb
+++ b/lib/re_jp_prefecture.rb
@@ -2,6 +2,7 @@
 
 require_relative "re_jp_prefecture/config"
 require_relative "re_jp_prefecture/jp_prefecture"
+require_relative "re_jp_prefecture/searchable"
 require_relative "re_jp_prefecture/prefecture"
 require_relative "re_jp_prefecture/version"
 

--- a/lib/re_jp_prefecture/searchable.rb
+++ b/lib/re_jp_prefecture/searchable.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module JpPrefecture
+  module Searchable
+    NAME_FIELDS = %i[name name_e name_r name_h name_k].freeze
+
+    def find_by_code(value)
+      return nil if value.nil?
+
+      all.find { |record| record.code == value }
+    end
+
+    NAME_FIELDS.each do |field|
+      define_method(:"find_by_#{field}") do |value|
+        return nil if value.nil? || value.to_s.empty?
+
+        query = value.to_s.downcase
+        all.find { |record| record.public_send(field).to_s.downcase.start_with?(query) }
+      end
+    end
+
+    def find_by_zip(value)
+      return nil if value.nil?
+
+      all.find { |record| record.zips.any? { |range| range.cover?(value) } }
+    end
+  end
+end

--- a/lib/re_jp_prefecture/searchable.rb
+++ b/lib/re_jp_prefecture/searchable.rb
@@ -37,9 +37,9 @@ module JpPrefecture
     private
 
     def find_by_string_prefix(value)
-      return nil if value.nil? || value.to_s.empty?
-
       query = value.to_s.downcase
+      return nil if query.empty?
+
       all.find { |record| yield(record).to_s.downcase.start_with?(query) }
     end
   end

--- a/lib/re_jp_prefecture/searchable.rb
+++ b/lib/re_jp_prefecture/searchable.rb
@@ -2,27 +2,45 @@
 
 module JpPrefecture
   module Searchable
-    NAME_FIELDS = %i[name name_e name_r name_h name_k].freeze
-
     def find_by_code(value)
       return nil if value.nil?
 
       all.find { |record| record.code == value }
     end
 
-    NAME_FIELDS.each do |field|
-      define_method(:"find_by_#{field}") do |value|
-        return nil if value.nil? || value.to_s.empty?
+    def find_by_name(value)
+      find_by_string_prefix(value, &:name)
+    end
 
-        query = value.to_s.downcase
-        all.find { |record| record.public_send(field).to_s.downcase.start_with?(query) }
-      end
+    def find_by_name_e(value)
+      find_by_string_prefix(value, &:name_e)
+    end
+
+    def find_by_name_r(value)
+      find_by_string_prefix(value, &:name_r)
+    end
+
+    def find_by_name_h(value)
+      find_by_string_prefix(value, &:name_h)
+    end
+
+    def find_by_name_k(value)
+      find_by_string_prefix(value, &:name_k)
     end
 
     def find_by_zip(value)
       return nil if value.nil?
 
       all.find { |record| record.zips.any? { |range| range.cover?(value) } }
+    end
+
+    private
+
+    def find_by_string_prefix(value)
+      return nil if value.nil? || value.to_s.empty?
+
+      query = value.to_s.downcase
+      all.find { |record| yield(record).to_s.downcase.start_with?(query) }
     end
   end
 end

--- a/spec/re_jp_prefecture/searchable_spec.rb
+++ b/spec/re_jp_prefecture/searchable_spec.rb
@@ -1,0 +1,155 @@
+# frozen_string_literal: true
+
+RSpec.describe JpPrefecture::Searchable do
+  let(:dummy_class) do
+    record_struct = Struct.new(:code, :name, :name_e, :name_r, :name_h, :name_k, :zips, keyword_init: true)
+    records = [
+      record_struct.new(
+        code: 1, name: "北海道", name_e: "hokkaido", name_r: "hokkaidō",
+        name_h: "ほっかいどう", name_k: "ホッカイドウ",
+        zips: [(10_000..70_895), (400_000..996_509)]
+      ),
+      record_struct.new(
+        code: 13, name: "東京都", name_e: "tokyo", name_r: "tōkyō",
+        name_h: "とうきょうと", name_k: "トウキョウト",
+        zips: [(1_000_001..2_088_504)]
+      ),
+      record_struct.new(
+        code: 27, name: "大阪府", name_e: "osaka", name_r: "ōsaka",
+        name_h: "おおさかふ", name_k: "オオサカフ",
+        zips: [(5_300_001..5_999_999)]
+      )
+    ]
+    Class.new do
+      extend JpPrefecture::Searchable
+      define_singleton_method(:all) { records }
+    end
+  end
+
+  describe ".find_by_code" do
+    it "完全一致でインスタンスを返す" do
+      result = dummy_class.find_by_code(13)
+      expect(result.name).to eq("東京都")
+    end
+
+    it "該当なしの場合は nil を返す" do
+      expect(dummy_class.find_by_code(99)).to be_nil
+    end
+
+    it "nil 入力に対しては nil を返す" do
+      expect(dummy_class.find_by_code(nil)).to be_nil
+    end
+  end
+
+  describe ".find_by_name" do
+    it "前方一致でインスタンスを返す" do
+      expect(dummy_class.find_by_name("東京").name).to eq("東京都")
+    end
+
+    it "完全一致でも返す" do
+      expect(dummy_class.find_by_name("北海道").name).to eq("北海道")
+    end
+
+    it "部分一致（前方ではない）はマッチしない" do
+      expect(dummy_class.find_by_name("京都")).to be_nil
+    end
+
+    it "該当なしの場合は nil を返す" do
+      expect(dummy_class.find_by_name("沖縄")).to be_nil
+    end
+
+    it "nil / 空文字入力に対しては nil を返す" do
+      expect(dummy_class.find_by_name(nil)).to be_nil
+      expect(dummy_class.find_by_name("")).to be_nil
+    end
+  end
+
+  describe ".find_by_name_e" do
+    it "前方一致・大文字小文字無視で返す" do
+      expect(dummy_class.find_by_name_e("TOK").name).to eq("東京都")
+      expect(dummy_class.find_by_name_e("hok").name).to eq("北海道")
+    end
+
+    it "該当なしの場合は nil を返す" do
+      expect(dummy_class.find_by_name_e("xyz")).to be_nil
+    end
+  end
+
+  describe ".find_by_name_r" do
+    it "前方一致・大文字小文字無視で返す" do
+      expect(dummy_class.find_by_name_r("Tō").name).to eq("東京都")
+    end
+
+    it "該当なしの場合は nil を返す" do
+      expect(dummy_class.find_by_name_r("xyz")).to be_nil
+    end
+  end
+
+  describe ".find_by_name_h" do
+    it "前方一致で返す" do
+      expect(dummy_class.find_by_name_h("とうきょう").name).to eq("東京都")
+    end
+
+    it "該当なしの場合は nil を返す" do
+      expect(dummy_class.find_by_name_h("ふくおか")).to be_nil
+    end
+  end
+
+  describe ".find_by_name_k" do
+    it "前方一致で返す" do
+      expect(dummy_class.find_by_name_k("トウキョウ").name).to eq("東京都")
+    end
+
+    it "該当なしの場合は nil を返す" do
+      expect(dummy_class.find_by_name_k("フクオカ")).to be_nil
+    end
+  end
+
+  describe ".find_by_zip" do
+    it "zips レンジに含まれる郵便番号で逆引きする" do
+      expect(dummy_class.find_by_zip(1_000_001).name).to eq("東京都")
+    end
+
+    it "レンジ範囲外は nil を返す" do
+      expect(dummy_class.find_by_zip(99_999_999)).to be_nil
+    end
+
+    it "ゼロ落ち郵便番号でも一致する" do
+      expect(dummy_class.find_by_zip(60_000).name).to eq("北海道")
+    end
+
+    it "レンジの begin 値ちょうどに一致する" do
+      expect(dummy_class.find_by_zip(1_000_001).name).to eq("東京都")
+    end
+
+    it "レンジの end 値ちょうどに一致する" do
+      expect(dummy_class.find_by_zip(2_088_504).name).to eq("東京都")
+    end
+
+    it "複数 zip レンジの2番目にヒットするケースを返す" do
+      # 北海道は 10_000..70_895 と 400_000..996_509 の2レンジを持つ
+      expect(dummy_class.find_by_zip(500_000).name).to eq("北海道")
+    end
+
+    it "レンジ間の隙間値は nil を返す" do
+      # 北海道の 70_895 と 400_000 の間
+      expect(dummy_class.find_by_zip(70_896)).to be_nil
+    end
+
+    it "nil 入力に対しては nil を返す" do
+      expect(dummy_class.find_by_zip(nil)).to be_nil
+    end
+  end
+
+  describe "Template Method 契約" do
+    it "extend 先の .all を呼び出して検索する" do
+      expect(dummy_class).to receive(:all).and_call_original
+      dummy_class.find_by_code(1)
+    end
+
+    it "Searchable は .all を提供しない" do
+      expect(JpPrefecture::Searchable.instance_methods).not_to include(:all)
+      expect(JpPrefecture::Searchable.singleton_methods).not_to include(:all)
+    end
+  end
+end

--- a/spec/re_jp_prefecture/searchable_spec.rb
+++ b/spec/re_jp_prefecture/searchable_spec.rb
@@ -20,16 +20,18 @@ RSpec.describe JpPrefecture::Searchable do
   end
 
   let(:dummy_class) do
-    target = records
+    all_records = records
+
     Class.new do
       extend JpPrefecture::Searchable
-      define_singleton_method(:all) { target }
+      define_singleton_method(:all) { all_records }
     end
   end
 
   describe ".find_by_code" do
     it "完全一致でインスタンスを返す" do
       result = dummy_class.find_by_code(13)
+
       expect(result.name).to eq("東京都")
     end
 
@@ -145,6 +147,7 @@ RSpec.describe JpPrefecture::Searchable do
   describe "Template Method 契約" do
     it "extend 先の .all を呼び出して検索する" do
       expect(dummy_class).to receive(:all).and_call_original
+
       dummy_class.find_by_code(1)
     end
 

--- a/spec/re_jp_prefecture/searchable_spec.rb
+++ b/spec/re_jp_prefecture/searchable_spec.rb
@@ -1,28 +1,29 @@
 # frozen_string_literal: true
 
 RSpec.describe JpPrefecture::Searchable do
-  let(:dummy_class) do
-    record_struct = Struct.new(:code, :name, :name_e, :name_r, :name_h, :name_k, :zips, keyword_init: true)
-    records = [
-      record_struct.new(
-        code: 1, name: "北海道", name_e: "hokkaido", name_r: "hokkaidō",
-        name_h: "ほっかいどう", name_k: "ホッカイドウ",
-        zips: [(10_000..70_895), (400_000..996_509)]
-      ),
-      record_struct.new(
-        code: 13, name: "東京都", name_e: "tokyo", name_r: "tōkyō",
-        name_h: "とうきょうと", name_k: "トウキョウト",
-        zips: [(1_000_001..2_088_504)]
-      ),
-      record_struct.new(
-        code: 27, name: "大阪府", name_e: "osaka", name_r: "ōsaka",
-        name_h: "おおさかふ", name_k: "オオサカフ",
-        zips: [(5_300_001..5_999_999)]
-      )
+  let(:record_struct) do
+    Struct.new(:code, :name, :name_e, :name_r, :name_h, :name_k, :zips, keyword_init: true)
+  end
+
+  let(:records) do
+    [
+      record_struct.new(code: 1, name: "北海道", name_e: "hokkaido", name_r: "hokkaidō",
+                        name_h: "ほっかいどう", name_k: "ホッカイドウ",
+                        zips: [10_000..70_895, 400_000..996_509]),
+      record_struct.new(code: 13, name: "東京都", name_e: "tokyo", name_r: "tōkyō",
+                        name_h: "とうきょうと", name_k: "トウキョウト",
+                        zips: [1_000_001..2_088_504]),
+      record_struct.new(code: 27, name: "大阪府", name_e: "osaka", name_r: "ōsaka",
+                        name_h: "おおさかふ", name_k: "オオサカフ",
+                        zips: [5_300_001..5_999_999])
     ]
+  end
+
+  let(:dummy_class) do
+    target = records
     Class.new do
       extend JpPrefecture::Searchable
-      define_singleton_method(:all) { records }
+      define_singleton_method(:all) { target }
     end
   end
 

--- a/spec/re_jp_prefecture/searchable_spec.rb
+++ b/spec/re_jp_prefecture/searchable_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe JpPrefecture::Searchable do
 
   describe ".find_by_zip" do
     it "zips レンジに含まれる郵便番号で逆引きする" do
-      expect(dummy_class.find_by_zip(1_000_001).name).to eq("東京都")
+      expect(dummy_class.find_by_zip(1_500_000).name).to eq("東京都")
     end
 
     it "レンジ範囲外は nil を返す" do


### PR DESCRIPTION
## 概要

検索機能を提供する `JpPrefecture::Searchable` モジュールを実装。`Prefecture` など `.all` を実装するクラスに `extend` して使うことを想定。

closes #17

### 提供するメソッド
| メソッド | マッチング |
|---|---|
| `find_by_code` | 完全一致 |
| `find_by_name` / `find_by_name_e` / `find_by_name_r` / `find_by_name_h` / `find_by_name_k` | 前方一致・大文字小文字無視 |
| `find_by_zip` | 郵便番号レンジ逆引き |

該当なし時は `nil` を返す。Searchable は `.all` を提供せず、extend 先の `.all` を Template Method で呼び出す。

### 設計判断
- メソッド名は `find_by_*` プレフィックス（Issue #18 の Hash キー → メソッド名委譲と整合させやすい）
- `all_fields` はスコープ外（必要なら別 Issue で追加）
- RBS 型シグネチャは追加しない（過去コミット 685db02 で運用廃止済み）
- `extend Searchable` の `Prefecture` への組み込みは Issue #18 で対応

## 確認方法

```sh
bundle exec rspec spec/re_jp_prefecture/searchable_spec.rb
bundle exec rake
```

- 全 65 テスト Green
- RuboCop 無違反

## 影響範囲

- 新規ファイル: `lib/re_jp_prefecture/searchable.rb` / `spec/re_jp_prefecture/searchable_spec.rb`
- 修正: `lib/re_jp_prefecture.rb`（require_relative 1 行追加）
- 既存挙動への変更なし（モジュールは追加のみ、どこからも extend されていない）