### PR TITLE
feat: Prefecture.find 統合（引数正規化→Searchable委譲） (#18)

### DIFF
--- a/lib/re_jp_prefecture/prefecture.rb
+++ b/lib/re_jp_prefecture/prefecture.rb
@@ -35,12 +35,12 @@ module JpPrefecture
         all.find { |pref| pref.code == code }
       end
 
-      def find(args)
-        case args
+      def find(query)
+        case query
         when Integer
-          find_by_code(args)
+          find_by_code(query)
         when Hash
-          key, value = args.first
+          key, value = query.first
           return nil unless SEARCH_KEYS.include?(key)
 
           public_send(:"find_by_#{key}", value)

--- a/lib/re_jp_prefecture/prefecture.rb
+++ b/lib/re_jp_prefecture/prefecture.rb
@@ -4,7 +4,10 @@ require "yaml"
 
 module JpPrefecture
   class Prefecture
+    extend Searchable
+
     ATTRIBUTES = %i[code name name_e name_r name_h name_k area type zips].freeze
+    SEARCH_KEYS = %i[name name_e name_r name_h name_k zip].freeze
 
     attr_reader(*ATTRIBUTES)
 
@@ -30,6 +33,18 @@ module JpPrefecture
 
       def build_by_code(code)
         all.find { |pref| pref.code == code }
+      end
+
+      def find(args)
+        case args
+        when Integer
+          find_by_code(args)
+        when Hash
+          key, value = args.first
+          return nil unless SEARCH_KEYS.include?(key)
+
+          public_send(:"find_by_#{key}", value)
+        end
       end
 
       private

--- a/spec/re_jp_prefecture/prefecture_spec.rb
+++ b/spec/re_jp_prefecture/prefecture_spec.rb
@@ -151,28 +151,17 @@ RSpec.describe JpPrefecture::Prefecture do
       expect(described_class.find(99)).to be_nil
     end
 
-    it "name: キーは前方一致で検索する" do
-      expect(described_class.find(name: "東京").name).to eq("東京都")
-    end
-
-    it "name_e: キーは英名（小文字）で検索する" do
-      expect(described_class.find(name_e: "tokyo").name).to eq("東京都")
-    end
-
-    it "name_r: キーはローマ字で検索する" do
-      expect(described_class.find(name_r: "tōkyō").name).to eq("東京都")
-    end
-
-    it "name_h: キーはひらがなで検索する" do
-      expect(described_class.find(name_h: "とうきょう").name).to eq("東京都")
-    end
-
-    it "name_k: キーはカタカナで検索する" do
-      expect(described_class.find(name_k: "トウキョウ").name).to eq("東京都")
-    end
-
-    it "zip: キーは郵便番号で逆引きする" do
-      expect(described_class.find(zip: 1_000_001).name).to eq("東京都")
+    {
+      name: "東京",
+      name_e: "tokyo",
+      name_r: "tōkyō",
+      name_h: "とうきょう",
+      name_k: "トウキョウ",
+      zip: 1_000_001
+    }.each do |key, value|
+      it "#{key}: キーは Searchable#find_by_#{key} に委譲する" do
+        expect(described_class.find(key => value).name).to eq("東京都")
+      end
     end
 
     it "該当なしの場合は nil を返す" do

--- a/spec/re_jp_prefecture/prefecture_spec.rb
+++ b/spec/re_jp_prefecture/prefecture_spec.rb
@@ -140,6 +140,61 @@ RSpec.describe JpPrefecture::Prefecture do
     end
   end
 
+  describe ".find" do
+    it "Integer 引数はコード検索として委譲する" do
+      pref = described_class.find(13)
+      expect(pref).to be_a(described_class)
+      expect(pref.name).to eq("東京都")
+    end
+
+    it "存在しない Integer コードは nil を返す" do
+      expect(described_class.find(99)).to be_nil
+    end
+
+    it "name: キーは前方一致で検索する" do
+      expect(described_class.find(name: "東京").name).to eq("東京都")
+    end
+
+    it "name_e: キーは英名（小文字）で検索する" do
+      expect(described_class.find(name_e: "tokyo").name).to eq("東京都")
+    end
+
+    it "name_r: キーはローマ字で検索する" do
+      expect(described_class.find(name_r: "tōkyō").name).to eq("東京都")
+    end
+
+    it "name_h: キーはひらがなで検索する" do
+      expect(described_class.find(name_h: "とうきょう").name).to eq("東京都")
+    end
+
+    it "name_k: キーはカタカナで検索する" do
+      expect(described_class.find(name_k: "トウキョウ").name).to eq("東京都")
+    end
+
+    it "zip: キーは郵便番号で逆引きする" do
+      expect(described_class.find(zip: 1_000_001).name).to eq("東京都")
+    end
+
+    it "該当なしの場合は nil を返す" do
+      expect(described_class.find(name: "存在しない県")).to be_nil
+      expect(described_class.find(zip: 99_999_999)).to be_nil
+    end
+
+    it "未対応キーの場合は nil を返す" do
+      expect(described_class.find(unknown: "x")).to be_nil
+    end
+
+    it "Integer / Hash 以外の引数は nil を返す" do
+      expect(described_class.find(nil)).to be_nil
+      expect(described_class.find("13")).to be_nil
+    end
+
+    it "Hash の最初のキーで委譲する" do
+      result = described_class.find(name: "東京", zip: 1)
+      expect(result.name).to eq("東京都")
+    end
+  end
+
   describe "メモ化" do
     it "デフォルトYAMLは初回のみロードされる" do
       expect(YAML).to receive(:load_file).at_most(:twice).and_call_original


### PR DESCRIPTION
## 概要

Issue #18 対応。`Prefecture.find` の公開 API を実装し、複数の入力形式で都道府県を検索可能にした。

- `Prefecture.find(13)` → コード検索（`find_by_code` 委譲）
- `Prefecture.find(name: "東京都")` / `name_e:` / `name_r:` / `name_h:` / `name_k:` → 名称系検索
- `Prefecture.find(zip: 1000001)` → 郵便番号逆引き
- 該当なし・未対応キー・Integer/Hash 以外の引数は `nil` を返す

実装方針:
- `extend Searchable` で `find_by_*` 系メソッドをクラスメソッドとして取り込み
- `SEARCH_KEYS` 定数で許可キー（`name` / `name_e` / `name_r` / `name_h` / `name_k` / `zip`）を明示し、未対応キーへの委譲を防ぐ
- Hash で複数キーが渡された場合は最初のキーで委譲（issue 設計方針通り）

## 確認方法

- `bundle exec rake` → 77 examples, 0 failures / RuboCop offenses 0
- `bundle exec rspec spec/re_jp_prefecture/prefecture_spec.rb` で `.find` の各シナリオを検証
  - Integer 引数
  - `name:` / `name_e:` / `name_r:` / `name_h:` / `name_k:` のキーワード引数
  - `zip:` の逆引き
  - 該当なし時の `nil` 返却
  - 未対応キー / 不正型に対する `nil` 返却

## 影響範囲

- `lib/re_jp_prefecture/prefecture.rb` — `extend Searchable` / `SEARCH_KEYS` 定数 / `.find` 追加
- `spec/re_jp_prefecture/prefecture_spec.rb` — `.find` テスト追加

Closes #18