### PR TITLE
feat: Baseモジュール（ActiveRecord連携）実装 (#19)

### DIFF
--- a/lib/re_jp_prefecture.rb
+++ b/lib/re_jp_prefecture.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
 require_relative "re_jp_prefecture/config"
-require_relative "re_jp_prefecture/jp_prefecture"
 require_relative "re_jp_prefecture/searchable"
 require_relative "re_jp_prefecture/prefecture"
+require_relative "re_jp_prefecture/base"
+require_relative "re_jp_prefecture/jp_prefecture"
 require_relative "re_jp_prefecture/version"
 
 module ReJpPrefecture

--- a/lib/re_jp_prefecture/base.rb
+++ b/lib/re_jp_prefecture/base.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require_relative "searchable"
+require_relative "prefecture"
+
+module JpPrefecture
+  module Base
+    def jp_prefecture(column)
+      define_method(:prefecture) do
+        code = send(column)
+        return nil if code.nil?
+
+        Prefecture.build_by_code(code)
+      end
+    end
+  end
+end

--- a/lib/re_jp_prefecture/base.rb
+++ b/lib/re_jp_prefecture/base.rb
@@ -1,16 +1,12 @@
 # frozen_string_literal: true
 
-require_relative "searchable"
 require_relative "prefecture"
 
 module JpPrefecture
   module Base
     def jp_prefecture(column)
       define_method(:prefecture) do
-        code = send(column)
-        return nil if code.nil?
-
-        Prefecture.build_by_code(code)
+        Prefecture.build_by_code(send(column))
       end
     end
   end

--- a/lib/re_jp_prefecture/jp_prefecture.rb
+++ b/lib/re_jp_prefecture/jp_prefecture.rb
@@ -1,11 +1,9 @@
 # frozen_string_literal: true
 
 require_relative "config"
+require_relative "base"
 
 module JpPrefecture
-  module Base
-  end
-
   class << self
     def config
       @config ||= ReJpPrefecture::Config.new

--- a/spec/re_jp_prefecture/base_spec.rb
+++ b/spec/re_jp_prefecture/base_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+RSpec.describe JpPrefecture::Base do
+  let(:model_class) do
+    Class.new do
+      include JpPrefecture
+      jp_prefecture :prefecture_code
+
+      attr_accessor :prefecture_code
+
+      def initialize(prefecture_code)
+        @prefecture_code = prefecture_code
+      end
+    end
+  end
+
+  describe ".jp_prefecture" do
+    it "include したクラスでマクロが利用可能になる" do
+      klass = Class.new { include JpPrefecture }
+      expect(klass).to respond_to(:jp_prefecture)
+    end
+
+    it "指定したカラム名から prefecture インスタンスメソッドを定義する" do
+      instance = model_class.new(13)
+      expect(instance).to respond_to(:prefecture)
+    end
+
+    it "prefecture メソッドが対応する Prefecture インスタンスを返す" do
+      instance = model_class.new(13)
+      expect(instance.prefecture).to be_a(JpPrefecture::Prefecture)
+      expect(instance.prefecture.name).to eq("東京都")
+    end
+
+    it "コードが nil の場合は nil を返す" do
+      instance = model_class.new(nil)
+      expect(instance.prefecture).to be_nil
+    end
+
+    it "存在しないコードの場合は nil を返す" do
+      instance = model_class.new(99)
+      expect(instance.prefecture).to be_nil
+    end
+
+    it "カラム名は任意の名前を指定できる" do
+      klass = Class.new do
+        include JpPrefecture
+        jp_prefecture :pref_id
+
+        attr_accessor :pref_id
+
+        def initialize(pref_id)
+          @pref_id = pref_id
+        end
+      end
+
+      instance = klass.new(27)
+      expect(instance.prefecture.name).to eq("大阪府")
+    end
+
+    it "カラム名に文字列を指定しても動作する" do
+      klass = Class.new do
+        include JpPrefecture
+        jp_prefecture "prefecture_code"
+
+        attr_accessor :prefecture_code
+
+        def initialize(prefecture_code)
+          @prefecture_code = prefecture_code
+        end
+      end
+
+      expect(klass.new(1).prefecture.name).to eq("北海道")
+    end
+
+    it "クラス間で prefecture メソッドが干渉しない" do
+      other_class = Class.new do
+        include JpPrefecture
+        jp_prefecture :other_code
+
+        attr_accessor :other_code
+
+        def initialize(other_code)
+          @other_code = other_code
+        end
+      end
+
+      first = model_class.new(13)
+      second = other_class.new(27)
+
+      expect(first.prefecture.name).to eq("東京都")
+      expect(second.prefecture.name).to eq("大阪府")
+    end
+  end
+
+  describe "ActiveRecord 非依存" do
+    it "send(column) に応えるだけのオブジェクトでも動作する（Struct）" do
+      struct_class = Struct.new(:prefecture_code) do
+        include JpPrefecture
+        jp_prefecture :prefecture_code
+      end
+
+      expect(struct_class.new(13).prefecture.name).to eq("東京都")
+    end
+  end
+end

--- a/spec/re_jp_prefecture/base_spec.rb
+++ b/spec/re_jp_prefecture/base_spec.rb
@@ -1,18 +1,18 @@
 # frozen_string_literal: true
 
 RSpec.describe JpPrefecture::Base do
-  let(:model_class) do
+  def build_model_class(column)
     Class.new do
       include JpPrefecture
-      jp_prefecture :prefecture_code
+      jp_prefecture column
 
-      attr_accessor :prefecture_code
+      attr_accessor column
 
-      def initialize(prefecture_code)
-        @prefecture_code = prefecture_code
-      end
+      define_method(:initialize) { |value| send("#{column}=", value) }
     end
   end
+
+  let(:model_class) { build_model_class(:prefecture_code) }
 
   describe ".jp_prefecture" do
     it "include したクラスでマクロが利用可能になる" do
@@ -32,60 +32,26 @@ RSpec.describe JpPrefecture::Base do
     end
 
     it "コードが nil の場合は nil を返す" do
-      instance = model_class.new(nil)
-      expect(instance.prefecture).to be_nil
+      expect(model_class.new(nil).prefecture).to be_nil
     end
 
     it "存在しないコードの場合は nil を返す" do
-      instance = model_class.new(99)
-      expect(instance.prefecture).to be_nil
+      expect(model_class.new(99).prefecture).to be_nil
     end
 
     it "カラム名は任意の名前を指定できる" do
-      klass = Class.new do
-        include JpPrefecture
-        jp_prefecture :pref_id
-
-        attr_accessor :pref_id
-
-        def initialize(pref_id)
-          @pref_id = pref_id
-        end
-      end
-
-      instance = klass.new(27)
-      expect(instance.prefecture.name).to eq("大阪府")
+      klass = build_model_class(:pref_id)
+      expect(klass.new(27).prefecture.name).to eq("大阪府")
     end
 
     it "カラム名に文字列を指定しても動作する" do
-      klass = Class.new do
-        include JpPrefecture
-        jp_prefecture "prefecture_code"
-
-        attr_accessor :prefecture_code
-
-        def initialize(prefecture_code)
-          @prefecture_code = prefecture_code
-        end
-      end
-
+      klass = build_model_class("prefecture_code")
       expect(klass.new(1).prefecture.name).to eq("北海道")
     end
 
     it "クラス間で prefecture メソッドが干渉しない" do
-      other_class = Class.new do
-        include JpPrefecture
-        jp_prefecture :other_code
-
-        attr_accessor :other_code
-
-        def initialize(other_code)
-          @other_code = other_code
-        end
-      end
-
       first = model_class.new(13)
-      second = other_class.new(27)
+      second = build_model_class(:other_code).new(27)
 
       expect(first.prefecture.name).to eq("東京都")
       expect(second.prefecture.name).to eq("大阪府")


### PR DESCRIPTION
## 概要

Issue #19 対応。`JpPrefecture::Base` モジュールに `jp_prefecture` マクロを実装し、ActiveRecord モデル等で `prefecture` メソッドを生やせるようにする。

```ruby
class User < ApplicationRecord
  include JpPrefecture
  jp_prefecture :prefecture_code
end

user.prefecture        # => Prefecture インスタンス
user.prefecture.name   # => "東京都"
```

## 変更点

- `lib/re_jp_prefecture/base.rb` を新規作成し、`JpPrefecture::Base` を分離
- `jp_prefecture(column)` マクロを実装
  - `prefecture` インスタンスメソッドを動的定義
  - 内部で `Prefecture.build_by_code(send(column))` を呼ぶ
  - `code` が `nil` の場合は `nil` を返す
- ActiveRecord 非依存（`send(column)` だけ前提）
- `spec/re_jp_prefecture/base_spec.rb` を新規作成

## 確認方法

- `bundle exec rake`（RSpec 74 examples / RuboCop 0 offenses）
- ダミーモデル（`Struct` / 匿名クラス）でマクロが動作することを spec で検証

## 影響範囲

- `JpPrefecture` モジュール（窓口）の include 動作
- 既存の `Prefecture.build_by_code` を利用するため、Prefecture コアに依存

## 関連

- Closes #19
- 依存: #15 (JpPrefecture 窓口), #16 (Prefecture コア)