### PR TITLE
feat: 公開APIに本家jp_prefecture互換シグネチャを追加 (#29)

### DIFF
--- a/lib/re_jp_prefecture/base.rb
+++ b/lib/re_jp_prefecture/base.rb
@@ -4,9 +4,12 @@ require_relative "prefecture"
 
 module JpPrefecture
   module Base
-    def jp_prefecture(column)
-      define_method(:prefecture) do
-        Prefecture.find_by_code(public_send(column))
+    def jp_prefecture(column_name, options = {})
+      column_name = column_name.to_sym
+      method_name = options[:method_name] || :prefecture
+
+      define_method(method_name) do
+        Prefecture.find(public_send(column_name))
       end
     end
   end

--- a/lib/re_jp_prefecture/prefecture.rb
+++ b/lib/re_jp_prefecture/prefecture.rb
@@ -7,7 +7,7 @@ module JpPrefecture
     extend Searchable
 
     ATTRIBUTES = %i[code name name_e name_r name_h name_k area type zips].freeze
-    SEARCH_KEYS = %i[name name_e name_r name_h name_k zip].freeze
+    SEARCH_KEYS = (Searchable::ALL_FIELDS_KEYS + %i[all_fields]).freeze
 
     attr_reader(*ATTRIBUTES)
 
@@ -37,6 +37,8 @@ module JpPrefecture
         case query
         when Integer
           find_by_code(query)
+        when String
+          find_by_code(Integer(query, exception: false))
         when Hash
           key, value = query.first
           return nil unless SEARCH_KEYS.include?(key)

--- a/lib/re_jp_prefecture/searchable.rb
+++ b/lib/re_jp_prefecture/searchable.rb
@@ -2,6 +2,8 @@
 
 module JpPrefecture
   module Searchable
+    ALL_FIELDS_KEYS = %i[code name name_e name_r name_h name_k zip].freeze
+
     def find_by_code(value)
       return nil if value.nil?
 
@@ -32,6 +34,16 @@ module JpPrefecture
       return nil if value.nil?
 
       all.find { |record| record.zips.any? { |range| range.cover?(value) } }
+    end
+
+    def find_by_all_fields(value)
+      return nil if value.nil?
+
+      ALL_FIELDS_KEYS.each do |key|
+        result = public_send(:"find_by_#{key}", value)
+        return result if result
+      end
+      nil
     end
 
     private

--- a/spec/re_jp_prefecture/base_spec.rb
+++ b/spec/re_jp_prefecture/base_spec.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 RSpec.describe JpPrefecture::Base do
-  def build_model_class(column)
+  def build_model_class(column, options = {})
     Class.new do
       include JpPrefecture
-      jp_prefecture column
+      jp_prefecture column, options
 
       attr_accessor column
 
@@ -55,6 +55,24 @@ RSpec.describe JpPrefecture::Base do
 
       expect(first.prefecture.name).to eq("東京都")
       expect(second.prefecture.name).to eq("大阪府")
+    end
+
+    it "options[:method_name] で任意のメソッド名を定義できる" do
+      klass = build_model_class(:prefecture_code, method_name: :pref)
+      instance = klass.new(13)
+      expect(instance).to respond_to(:pref)
+      expect(instance.pref.name).to eq("東京都")
+    end
+
+    it "options[:method_name] 未指定時は :prefecture メソッドが定義される" do
+      instance = model_class.new(13)
+      expect(instance).to respond_to(:prefecture)
+    end
+
+    it "options[:method_name] 指定時は :prefecture が定義されない" do
+      klass = build_model_class(:prefecture_code, method_name: :pref)
+      expect(klass.instance_methods(false)).to include(:pref)
+      expect(klass.instance_methods(false)).not_to include(:prefecture)
     end
   end
 

--- a/spec/re_jp_prefecture/prefecture_spec.rb
+++ b/spec/re_jp_prefecture/prefecture_spec.rb
@@ -163,6 +163,7 @@ RSpec.describe JpPrefecture::Prefecture do
     end
 
     {
+      code: 1,
       name: "東京",
       name_e: "tokyo",
       name_r: "tōkyō",
@@ -171,8 +172,55 @@ RSpec.describe JpPrefecture::Prefecture do
       zip: 1_000_001
     }.each do |key, value|
       it "#{key}: キーは Searchable#find_by_#{key} に委譲する" do
-        expect(described_class.find(key => value).name).to eq("東京都")
+        result = described_class.find(key => value)
+        expect(result).to be_a(described_class)
       end
+    end
+
+    it "code: キーで北海道を返す" do
+      expect(described_class.find(code: 1).name).to eq("北海道")
+    end
+
+    it "code: キーで存在しないコードは nil を返す" do
+      expect(described_class.find(code: 99)).to be_nil
+    end
+
+    it "code: キーで nil 値は nil を返す" do
+      expect(described_class.find(code: nil)).to be_nil
+    end
+
+    it "all_fields: キーで漢字部分一致（前方）でインスタンスを返す" do
+      expect(described_class.find(all_fields: "東").name).to eq("東京都")
+    end
+
+    it "all_fields: キーで英字でインスタンスを返す" do
+      expect(described_class.find(all_fields: "Hokkaido").name).to eq("北海道")
+    end
+
+    it "all_fields: キーで Integer をコードとして解釈する" do
+      expect(described_class.find(all_fields: 1).name).to eq("北海道")
+    end
+
+    it "all_fields: キーで nil 値は nil を返す" do
+      expect(described_class.find(all_fields: nil)).to be_nil
+    end
+
+    it "all_fields: キーでヒットしない値は nil を返す" do
+      expect(described_class.find(all_fields: "存在しない県")).to be_nil
+    end
+
+    it "String 引数（コード文字列）はコード検索として委譲する" do
+      expect(described_class.find("1").name).to eq("北海道")
+      expect(described_class.find("13").name).to eq("東京都")
+    end
+
+    it "String 引数で存在しないコードは nil を返す" do
+      expect(described_class.find("99")).to be_nil
+    end
+
+    it "String 引数で数値変換できない場合は nil を返す（例外を投げない）" do
+      expect { described_class.find("abc") }.not_to raise_error
+      expect(described_class.find("abc")).to be_nil
     end
 
     it "該当なしの場合は nil を返す" do
@@ -184,9 +232,8 @@ RSpec.describe JpPrefecture::Prefecture do
       expect(described_class.find(unknown: "x")).to be_nil
     end
 
-    it "Integer / Hash 以外の引数は nil を返す" do
+    it "nil 引数は nil を返す" do
       expect(described_class.find(nil)).to be_nil
-      expect(described_class.find("13")).to be_nil
     end
 
     it "Hash の最初のキーで委譲する" do

--- a/spec/re_jp_prefecture/searchable_spec.rb
+++ b/spec/re_jp_prefecture/searchable_spec.rb
@@ -144,6 +144,44 @@ RSpec.describe JpPrefecture::Searchable do
     end
   end
 
+  describe ".find_by_all_fields" do
+    it "Integer をコードとして解釈してインスタンスを返す" do
+      expect(dummy_class.find_by_all_fields(1).name).to eq("北海道")
+    end
+
+    it "name の前方一致でインスタンスを返す" do
+      expect(dummy_class.find_by_all_fields("東").name).to eq("東京都")
+    end
+
+    it "name_e（英字）の前方一致でインスタンスを返す" do
+      expect(dummy_class.find_by_all_fields("Hokkaido").name).to eq("北海道")
+    end
+
+    it "name_r（ローマ字）の前方一致でインスタンスを返す" do
+      expect(dummy_class.find_by_all_fields("ōsa").name).to eq("大阪府")
+    end
+
+    it "name_h（ひらがな）の前方一致でインスタンスを返す" do
+      expect(dummy_class.find_by_all_fields("おおさか").name).to eq("大阪府")
+    end
+
+    it "name_k（カタカナ）の前方一致でインスタンスを返す" do
+      expect(dummy_class.find_by_all_fields("オオサカ").name).to eq("大阪府")
+    end
+
+    it "zip 範囲でインスタンスを返す" do
+      expect(dummy_class.find_by_all_fields(1_500_000).name).to eq("東京都")
+    end
+
+    it "ヒットしない値は nil を返す" do
+      expect(dummy_class.find_by_all_fields("存在しない")).to be_nil
+    end
+
+    it "nil 入力に対しては nil を返す" do
+      expect(dummy_class.find_by_all_fields(nil)).to be_nil
+    end
+  end
+
   describe "Template Method 契約" do
     it "extend 先の .all を呼び出して検索する" do
       expect(dummy_class).to receive(:all).and_call_original


### PR DESCRIPTION
## 概要

本家 `jp_prefecture` gem の公開API互換性を追加する。既存設計（`Searchable` 委譲、`build_by_code` の内部実装、`ReJpPrefecture::Config` 名前空間）は不変で、シグネチャ・受付値の拡張のみで対応する。

- `Base#jp_prefecture` に `options[:method_name]` を追加（任意のメソッド名で定義可能）
- `Base#jp_prefecture` の内部呼出しを `Prefecture.build_by_code` → `Prefecture.find` に変更
- `Prefecture.find` に `String` 引数（コード文字列）対応を追加（変換不可なら nil、例外は投げない）
- `Prefecture::SEARCH_KEYS` に `:code` / `:all_fields` を追加
- `Searchable#find_by_all_fields` を新規追加（`find_by_code/name/name_e/name_r/name_h/name_k/zip` を順に試して最初にヒットしたインスタンスを返す）

## 確認方法

```sh
bundle exec rake
```

- 110 examples, 0 failures
- RuboCop: 19 files inspected, no offenses detected

新規ケースの spec を追加済み:

- `spec/re_jp_prefecture/searchable_spec.rb`: `.find_by_all_fields` の網羅ケース
- `spec/re_jp_prefecture/prefecture_spec.rb`: `code:` / `all_fields:` / `String` 引数の網羅ケース
- `spec/re_jp_prefecture/base_spec.rb`: `options[:method_name]` の動作

## 影響範囲

- `lib/re_jp_prefecture/base.rb`
- `lib/re_jp_prefecture/prefecture.rb`
- `lib/re_jp_prefecture/searchable.rb`

Closes #29